### PR TITLE
refactor: change all ID types from number to string for UUID compatibility

### DIFF
--- a/nuxt-app/app/components/project/tabs/ProjectTabsBoard.vue
+++ b/nuxt-app/app/components/project/tabs/ProjectTabsBoard.vue
@@ -2,7 +2,7 @@
 import type { TaskStatus, Task } from "~/types";
 
 interface Props {
-  projectId: number;
+  projectId: string;
 }
 
 const { projectId } = defineProps<Props>();
@@ -10,7 +10,7 @@ const { projectId } = defineProps<Props>();
 const router = useRouter();
 const { tasks, isLoading, updateTask } = useTasks(projectId);
 
-const handleTaskMove = async (taskId: number, newStatus: TaskStatus) => {
+const handleTaskMove = async (taskId: string, newStatus: TaskStatus) => {
   try {
     await updateTask(taskId, { status: newStatus });
   } catch (err) {

--- a/nuxt-app/app/components/project/tabs/ProjectTabsMembers.vue
+++ b/nuxt-app/app/components/project/tabs/ProjectTabsMembers.vue
@@ -9,7 +9,7 @@ import {
 } from "lucide-vue-next";
 
 interface Props {
-  projectId: number;
+  projectId: string;
 }
 
 const { projectId } = defineProps<Props>();
@@ -37,7 +37,7 @@ const handleInvite = async () => {
   }
 };
 
-const handleRemoveMember = async (userId: number) => {
+const handleRemoveMember = async (userId: string) => {
   if (!confirm("Remove this member from the project?")) return;
   try {
     await removeMember(userId);
@@ -50,7 +50,7 @@ const handleLinkTeam = async () => {
   if (!selectedTeamId.value) return;
   isLinking.value = true;
   try {
-    await addTeam(parseInt(selectedTeamId.value));
+    await addTeam(selectedTeamId.value);
     selectedTeamId.value = "";
   } catch (err) {
     alert(getApiErrorMessage(err, "Failed to link team"));
@@ -59,7 +59,7 @@ const handleLinkTeam = async () => {
   }
 };
 
-const handleUnlinkTeam = async (teamId: number) => {
+const handleUnlinkTeam = async (teamId: string) => {
   if (!confirm("Unlink this team from the project?")) return;
   try {
     await removeTeam(teamId);

--- a/nuxt-app/app/components/project/tabs/ProjectTabsTasks.vue
+++ b/nuxt-app/app/components/project/tabs/ProjectTabsTasks.vue
@@ -10,7 +10,7 @@ import {
 import { TaskStatus, type Task } from "~/types";
 
 interface Props {
-  projectId: number;
+  projectId: string;
 }
 
 const { projectId } = defineProps<Props>();

--- a/nuxt-app/app/components/settings/SettingsMembers.vue
+++ b/nuxt-app/app/components/settings/SettingsMembers.vue
@@ -68,7 +68,7 @@ const handleInvite = async () => {
   }
 };
 
-const handleRemove = async (userId: number) => {
+const handleRemove = async (userId: string) => {
   if (
     !activeWorkspace.value ||
     !confirm("Are you sure you want to remove this member?")

--- a/nuxt-app/app/components/tasks/CommentItem.vue
+++ b/nuxt-app/app/components/tasks/CommentItem.vue
@@ -5,17 +5,17 @@ import type { Comment } from "~/types";
 
 interface Props {
   comment: Comment;
-  currentUserId?: number;
+  currentUserId?: string;
 }
 
-const { comment, currentUserId = 0 } = defineProps<Props>();
+const { comment, currentUserId = "" } = defineProps<Props>();
 
 const emit = defineEmits(["delete"]);
 
 const author = computed(
   () =>
     comment.author || {
-      id: 0,
+      id: "",
       email: "unknown@user.com",
       full_name: "Unknown User",
     }

--- a/nuxt-app/app/components/tasks/Dialog.vue
+++ b/nuxt-app/app/components/tasks/Dialog.vue
@@ -6,23 +6,23 @@ import { useUsersStore } from "~/stores/user";
 interface Props {
   isOpen?: boolean;
   task?: Task | null;
-  projectId?: number;
+  projectId?: string;
 }
 
-const { isOpen = false, task = null, projectId = 0 } = defineProps<Props>();
+const { isOpen = false, task = null, projectId = "" } = defineProps<Props>();
 
 const emit = defineEmits(["close"]);
 
 const userStore = useUsersStore();
 const currentUserId = computed(() => userStore.userData?.id);
 
-const activeProjectId = computed(() => projectId || task?.project_id || 0);
+const activeProjectId = computed(() => projectId || task?.project_id || "");
 
 const { createTask, updateTask, deleteTask } = useTasks(activeProjectId.value);
 const { members } = useProjectMembers(activeProjectId.value);
 
 // For existing tasks, use useTask hook for comments
-const taskId = computed(() => task?.id || 0);
+const taskId = computed(() => task?.id || "");
 const {
   comments,
   isLoading: detailsLoading,
@@ -39,7 +39,7 @@ const formData = ref({
   description: "",
   status: TaskStatus.TODO,
   priority: TaskPriority.P2,
-  assignee_id: null as number | null,
+  assignee_id: null as string | null,
   due_date: "" as string | undefined,
 });
 

--- a/nuxt-app/app/components/tasks/IssueItem.vue
+++ b/nuxt-app/app/components/tasks/IssueItem.vue
@@ -13,7 +13,7 @@ import { TaskStatus, TaskPriority, type Task } from "~/types";
 
 interface Props {
   task: Task;
-  projectId: number;
+  projectId: string;
 }
 
 const { task, projectId } = defineProps<Props>();

--- a/nuxt-app/app/components/tasks/board/View.vue
+++ b/nuxt-app/app/components/tasks/board/View.vue
@@ -20,7 +20,7 @@ const getTasksByStatus = (status: TaskStatus) => {
   return tasks.filter((t) => t.status === status);
 };
 
-const handleTaskMove = (event: { taskId: number; newStatus: TaskStatus }) => {
+const handleTaskMove = (event: { taskId: string; newStatus: TaskStatus }) => {
   emit("task-move", event.taskId, event.newStatus);
 };
 </script>

--- a/nuxt-app/app/components/tasks/selectors/AssigneeSelector.vue
+++ b/nuxt-app/app/components/tasks/selectors/AssigneeSelector.vue
@@ -11,7 +11,7 @@ import type { ProjectMember } from "~/types";
 
 interface Props {
   members?: ProjectMember[];
-  modelValue?: number | null;
+  modelValue?: string | null;
   disabled?: boolean;
 }
 
@@ -26,7 +26,7 @@ const selected = computed(
   () => members.find((m) => m.user_id === modelValue) || null
 );
 
-const handleChange = (value: number | null) => {
+const handleChange = (value: string | null) => {
   emit("update:modelValue", value);
   emit("change", value);
 };

--- a/nuxt-app/app/components/team/tabs/Members.vue
+++ b/nuxt-app/app/components/team/tabs/Members.vue
@@ -2,7 +2,7 @@
 import { Loader2, Trash2, UserPlus, Mail } from "lucide-vue-next";
 
 interface Props {
-  teamId: number;
+  teamId: string;
 }
 
 const { teamId } = defineProps<Props>();
@@ -25,7 +25,7 @@ const handleInvite = async () => {
   }
 };
 
-const handleRemoveMember = async (userId: number) => {
+const handleRemoveMember = async (userId: string) => {
   if (!confirm("Remove this member from the team?")) return;
   try {
     await removeMember(userId);

--- a/nuxt-app/app/components/team/tabs/Overview.vue
+++ b/nuxt-app/app/components/team/tabs/Overview.vue
@@ -3,7 +3,7 @@ import { Folder, ArrowRight, Loader2 } from "lucide-vue-next";
 import { format } from "date-fns";
 
 interface Props {
-  teamId: number;
+  teamId: string;
 }
 
 const { teamId } = defineProps<Props>();

--- a/nuxt-app/app/components/workspace/Switcher.vue
+++ b/nuxt-app/app/components/workspace/Switcher.vue
@@ -13,7 +13,7 @@ useClickOutside(dropdownRef, () => {
   isOpen.value = false;
 });
 
-const handleSelect = (id: number) => {
+const handleSelect = (id: string) => {
   workspaceStore.setActiveWorkspaceId(id);
   isOpen.value = false;
 };

--- a/nuxt-app/app/composables/useMyTasks.ts
+++ b/nuxt-app/app/composables/useMyTasks.ts
@@ -10,7 +10,7 @@ export const useMyTasks = () => {
     key: "my-tasks",
   });
 
-  const updateTask = async (taskId: number, updates: Partial<Task>) => {
+  const updateTask = async (taskId: string, updates: Partial<Task>) => {
     try {
       await useMutation(`/api/v1/tasks/${taskId}`, {
         method: "PATCH",

--- a/nuxt-app/app/composables/useProjects.ts
+++ b/nuxt-app/app/composables/useProjects.ts
@@ -45,7 +45,7 @@ export const useProjects = () => {
   };
 };
 
-export const useProject = (id: number) => {
+export const useProject = (id: string) => {
   const {
     data: project,
     pending: isLoading,
@@ -63,7 +63,7 @@ export const useProject = (id: number) => {
   };
 };
 
-export const useProjectMembers = (projectId: number) => {
+export const useProjectMembers = (projectId: string) => {
   const {
     data: members,
     pending: isLoading,
@@ -86,7 +86,7 @@ export const useProjectMembers = (projectId: number) => {
     }
   };
 
-  const removeMember = async (userId: number) => {
+  const removeMember = async (userId: string) => {
     try {
       await useMutation(`/api/v1/projects/${projectId}/members/${userId}`, {
         method: "DELETE",
@@ -108,7 +108,7 @@ export const useProjectMembers = (projectId: number) => {
   };
 };
 
-export const useProjectTeams = (projectId: number) => {
+export const useProjectTeams = (projectId: string) => {
   const {
     data: teams,
     pending: isLoading,
@@ -118,7 +118,7 @@ export const useProjectTeams = (projectId: number) => {
     key: `project-teams-${projectId}`,
   });
 
-  const addTeam = async (teamId: number) => {
+  const addTeam = async (teamId: string) => {
     try {
       await useMutation(`/api/v1/projects/${projectId}/teams`, {
         method: "POST",
@@ -131,7 +131,7 @@ export const useProjectTeams = (projectId: number) => {
     }
   };
 
-  const removeTeam = async (teamId: number) => {
+  const removeTeam = async (teamId: string) => {
     try {
       await useMutation(`/api/v1/projects/${projectId}/teams/${teamId}`, {
         method: "DELETE",

--- a/nuxt-app/app/composables/useTasks.ts
+++ b/nuxt-app/app/composables/useTasks.ts
@@ -1,6 +1,6 @@
 import type { Task, Comment, TaskPriority, TaskStatus } from "~/types";
 
-export const useTasks = (projectId?: number) => {
+export const useTasks = (projectId?: string) => {
   const {
     data: tasks,
     pending: isLoading,
@@ -19,7 +19,7 @@ export const useTasks = (projectId?: number) => {
     description?: string;
     priority?: TaskPriority;
     status?: TaskStatus;
-    assignee_id?: number;
+    assignee_id?: string;
     due_date?: string;
   }) => {
     if (!projectId) return;
@@ -35,7 +35,7 @@ export const useTasks = (projectId?: number) => {
     }
   };
 
-  const updateTask = async (taskId: number, updates: Partial<Task>) => {
+  const updateTask = async (taskId: string, updates: Partial<Task>) => {
     try {
       await useMutation(`/api/v1/tasks/${taskId}`, {
         method: "PATCH",
@@ -48,7 +48,7 @@ export const useTasks = (projectId?: number) => {
     }
   };
 
-  const deleteTask = async (taskId: number) => {
+  const deleteTask = async (taskId: string) => {
     try {
       await useMutation(`/api/v1/tasks/${taskId}`, {
         method: "DELETE",
@@ -71,7 +71,7 @@ export const useTasks = (projectId?: number) => {
   };
 };
 
-export const useTask = (taskId: number) => {
+export const useTask = (taskId: string) => {
   const {
     data: task,
     pending: taskLoading,
@@ -103,7 +103,7 @@ export const useTask = (taskId: number) => {
     }
   };
 
-  const deleteComment = async (commentId: number) => {
+  const deleteComment = async (commentId: string) => {
     try {
       await useMutation(`/api/v1/comments/${commentId}`, {
         method: "DELETE",

--- a/nuxt-app/app/composables/useTeams.ts
+++ b/nuxt-app/app/composables/useTeams.ts
@@ -37,7 +37,7 @@ export const useTeams = () => {
   };
 
   const updateTeam = async (
-    teamId: number,
+    teamId: string,
     data: { name?: string; description?: string }
   ) => {
     if (!workspaceStore.activeWorkspaceId) return;
@@ -56,7 +56,7 @@ export const useTeams = () => {
     }
   };
 
-  const deleteTeam = async (teamId: number) => {
+  const deleteTeam = async (teamId: string) => {
     if (!workspaceStore.activeWorkspaceId) return;
     try {
       await useMutation(
@@ -83,7 +83,7 @@ export const useTeams = () => {
   };
 };
 
-export const useTeam = (teamId: number) => {
+export const useTeam = (teamId: string) => {
   const workspaceStore = useWorkspaceStore();
 
   const {
@@ -109,7 +109,7 @@ export const useTeam = (teamId: number) => {
   };
 };
 
-export const useTeamMembers = (teamId: number) => {
+export const useTeamMembers = (teamId: string) => {
   const workspaceStore = useWorkspaceStore();
 
   const {
@@ -144,7 +144,7 @@ export const useTeamMembers = (teamId: number) => {
     }
   };
 
-  const removeMember = async (userId: number) => {
+  const removeMember = async (userId: string) => {
     if (!workspaceStore.activeWorkspaceId) return;
     try {
       await useMutation(

--- a/nuxt-app/app/pages/boards.vue
+++ b/nuxt-app/app/pages/boards.vue
@@ -7,7 +7,7 @@ definePageMeta({ layout: "dashboard" });
 const { tasks, isLoading, updateTask, refresh } = useMyTasks();
 const isDialogOpen = ref(false);
 
-const handleTaskMove = async (taskId: number, newStatus: TaskStatus) => {
+const handleTaskMove = async (taskId: string, newStatus: TaskStatus) => {
   try {
     await updateTask(taskId, { status: newStatus });
   } catch (err) {

--- a/nuxt-app/app/pages/projects/[projectId]/index.vue
+++ b/nuxt-app/app/pages/projects/[projectId]/index.vue
@@ -4,7 +4,7 @@ import { Loader2 } from "lucide-vue-next";
 definePageMeta({ layout: "dashboard" });
 
 const route = useRoute();
-const projectId = computed(() => parseInt(route.params.projectId as string));
+const projectId = computed(() => route.params.projectId as string);
 
 const { project, isLoading } = useProject(projectId.value);
 

--- a/nuxt-app/app/pages/projects/[projectId]/tasks/[taskId].vue
+++ b/nuxt-app/app/pages/projects/[projectId]/tasks/[taskId].vue
@@ -24,8 +24,8 @@ definePageMeta({
 
 const route = useRoute();
 const router = useRouter();
-const projectId = computed(() => parseInt(route.params.projectId as string));
-const taskId = computed(() => parseInt(route.params.taskId as string));
+const projectId = computed(() => route.params.projectId as string);
+const taskId = computed(() => route.params.taskId as string);
 
 const userStore = useUsersStore();
 const currentUserId = computed(() => userStore.userData?.id);
@@ -64,7 +64,7 @@ const handleUpdatePriority = async (priority: TaskPriority) => {
   await refreshTask();
 };
 
-const handleUpdateAssignee = async (assigneeId: number | null) => {
+const handleUpdateAssignee = async (assigneeId: string | null) => {
   await updateTask(taskId.value, { assignee_id: assigneeId || undefined });
   await refreshTask();
 };
@@ -105,7 +105,7 @@ const handleSubmitComment = async () => {
   }
 };
 
-const handleDeleteComment = async (id: number) => {
+const handleDeleteComment = async (id: string) => {
   if (!confirm("Delete this comment?")) return;
   try {
     await deleteComment(id);

--- a/nuxt-app/app/pages/projects/[projectId]/tasks/new.vue
+++ b/nuxt-app/app/pages/projects/[projectId]/tasks/new.vue
@@ -8,7 +8,7 @@ definePageMeta({
 
 const route = useRoute();
 const router = useRouter();
-const projectId = computed(() => parseInt(route.params.projectId as string));
+const projectId = computed(() => route.params.projectId as string);
 
 const { createTask } = useTasks(projectId.value);
 const { members } = useProjectMembers(projectId.value);
@@ -19,7 +19,7 @@ const formData = ref({
   description: "",
   status: TaskStatus.TODO,
   priority: TaskPriority.P2,
-  assignee_id: null as number | null,
+  assignee_id: null as string | null,
   due_date: "",
 });
 

--- a/nuxt-app/app/pages/teams/[teamId].vue
+++ b/nuxt-app/app/pages/teams/[teamId].vue
@@ -4,7 +4,7 @@ import { Loader2 } from "lucide-vue-next";
 definePageMeta({ layout: "dashboard" });
 
 const route = useRoute();
-const teamId = computed(() => parseInt(route.params.teamId as string));
+const teamId = computed(() => route.params.teamId as string);
 
 const { team, isLoading } = useTeam(teamId.value);
 

--- a/nuxt-app/app/stores/project.ts
+++ b/nuxt-app/app/stores/project.ts
@@ -3,9 +3,9 @@ import { defineStore } from "pinia";
 export const useProjectStore = defineStore(
   "project",
   () => {
-    const activeProjectId = ref<number | null>(null);
+    const activeProjectId = ref<string | null>(null);
 
-    const setActiveProjectId = (id: number | null) => {
+    const setActiveProjectId = (id: string | null) => {
       activeProjectId.value = id;
     };
 

--- a/nuxt-app/app/stores/workspace.ts
+++ b/nuxt-app/app/stores/workspace.ts
@@ -2,10 +2,10 @@ import { defineStore } from "pinia";
 
 export const useWorkspaceStore = defineStore("workspace", {
   state: () => ({
-    activeWorkspaceId: null as number | null,
+    activeWorkspaceId: null as string | null,
   }),
   actions: {
-    setActiveWorkspaceId(id: number) {
+    setActiveWorkspaceId(id: string) {
       this.activeWorkspaceId = id;
     },
   },

--- a/nuxt-app/app/types/index.ts
+++ b/nuxt-app/app/types/index.ts
@@ -10,25 +10,25 @@ export enum WorkspaceRole {
 }
 
 export interface Workspace {
-  id: number;
+  id: string;
   name: string;
   type: WorkspaceType;
-  owner_id: number;
+  owner_id: string;
 }
 
 export interface User {
-  id: number;
+  id: string;
   email: string;
   is_active: boolean;
   full_name?: string;
 }
 
 export interface WorkspaceMember {
-  workspace_id: number;
-  user_id: number;
+  workspace_id: string;
+  user_id: string;
   role: WorkspaceRole;
   user: {
-    id: number;
+    id: string;
     email: string;
     full_name?: string;
   };
@@ -41,17 +41,17 @@ export enum TeamRole {
 }
 
 export interface Team {
-  id: number;
+  id: string;
   name: string;
   description?: string;
-  workspace_id: number;
+  workspace_id: string;
   created_at: string;
   projects?: Project[];
 }
 
 export interface TeamMember {
-  team_id: number;
-  user_id: number;
+  team_id: string;
+  user_id: string;
   role: TeamRole;
   email: string; // Flattened for display
 }
@@ -64,25 +64,25 @@ export enum ProjectRole {
 }
 
 export interface Project {
-  id: number;
+  id: string;
   name: string;
   description?: string;
-  workspace_id: number;
+  workspace_id: string;
   created_at: string;
   is_archived: boolean;
 }
 
 export interface ProjectMember {
-  project_id: number;
-  user_id: number;
+  project_id: string;
+  user_id: string;
   role: ProjectRole;
   email: string; // Flattened for display
   is_direct: boolean;
 }
 
 export interface ProjectTeam {
-  project_id: number;
-  team_id: number;
+  project_id: string;
+  team_id: string;
   team_name: string;
 }
 
@@ -102,20 +102,20 @@ export enum TaskPriority {
 }
 
 export interface Task {
-  id: number;
+  id: string;
   title: string;
   description?: string;
   status: TaskStatus;
   priority: TaskPriority;
-  project_id: number; // Updated from workspace_id
-  assignee_id?: number;
+  project_id: string; // Updated from workspace_id
+  assignee_id?: string;
   assignee?: {
-    id: number;
+    id: string;
     email: string;
     full_name?: string;
   };
   author?: {
-    id: number;
+    id: string;
     email: string;
     full_name?: string;
   };
@@ -127,7 +127,7 @@ export interface Task {
 }
 
 export interface ProjectInfo {
-  id: number;
+  id: string;
   name: string;
 }
 
@@ -136,12 +136,12 @@ export interface TaskWithProject extends Task {
 }
 
 export interface Comment {
-  id: number;
+  id: string;
   content: string;
-  task_id: number;
-  author_id: number;
+  task_id: string;
+  author_id: string;
   author?: {
-    id: number;
+    id: string;
     email: string;
     full_name?: string;
   };


### PR DESCRIPTION
## Description
This PR performs a global refactor of the ID type system in the Nuxt application. All `id` and foreign key fields (e.g., `project_id`, `user_id`, `taskId`) have been transitioned from `number` to `string` to maintain compatibility with the backend's UUID implementation.

## Linked Issue
- Fixes: #122

## Changes
- **Types**: Refactored `app/types/index.ts` to use `string` for all identity fields.
- **Routing**: Removed all `parseInt()` calls from page route parameters.
- **State Management**: Updated Pinia stores (`workspace`, `project`) to store IDs as strings.
- **Composables**: Updated `useProjects`, `useTasks`, `useTeams`, and `useApi` to accept string IDs.
- **Components**: Updated props and logic in over 15 components to handle string-based UUIDs.

## Verification
- [x] Verified that project and task pages load correctly using UUIDs.
- [x] Confirmed that "Project not found" and `NaN` errors are resolved.
- [x] Verified that all API calls now send the correct string format for IDs.
- [x] Performed a full grep search to ensure no `parseInt` calls remain on ID fields.
