### PR TITLE
refactor: align frontend API calls with backend nested workspace routes

### DIFF
--- a/golang-backend/models/project.go
+++ b/golang-backend/models/project.go
@@ -241,6 +241,7 @@ func (model *ProjectModel) ListByTeamID(teamID uuid.UUID) ([]Project, error) {
 	var projects []Project
 	err := model.db.From(ProjectTable).
 		Join(goqu.T(ProjectTeamTable), goqu.On(goqu.Ex{ProjectTable + ".id": goqu.I(ProjectTeamTable + ".project_id")})).
+		Select(ProjectTable + ".*").
 		Where(goqu.Ex{
 			ProjectTeamTable + ".team_id": teamID,
 			ProjectTable + ".is_archived": false,

--- a/nuxt-app/app/components/tasks/Dialog.vue
+++ b/nuxt-app/app/components/tasks/Dialog.vue
@@ -28,7 +28,7 @@ const {
   isLoading: detailsLoading,
   createComment,
   deleteComment,
-} = useTask(taskId.value);
+} = useTask(activeProjectId.value, taskId.value);
 
 const isSaving = ref(false);
 const newComment = ref("");

--- a/nuxt-app/app/composables/useProjects.ts
+++ b/nuxt-app/app/composables/useProjects.ts
@@ -46,14 +46,22 @@ export const useProjects = () => {
 };
 
 export const useProject = (id: string) => {
+  const workspaceStore = useWorkspaceStore();
+
   const {
     data: project,
     pending: isLoading,
     error,
     refresh,
-  } = useApi<Project>(`/api/v1/projects/${id}`, {
-    key: `project-${id}`,
-  });
+  } = useApi<Project>(
+    () =>
+      workspaceStore.activeWorkspaceId
+        ? `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${id}`
+        : `/api/v1/workspaces/0/projects/${id}`,
+    {
+      key: `project-${id}`,
+    }
+  );
 
   return {
     project,
@@ -64,21 +72,33 @@ export const useProject = (id: string) => {
 };
 
 export const useProjectMembers = (projectId: string) => {
+  const workspaceStore = useWorkspaceStore();
+
   const {
     data: members,
     pending: isLoading,
     error,
     refresh,
-  } = useApi<ProjectMember[]>(`/api/v1/projects/${projectId}/members`, {
-    key: `project-members-${projectId}`,
-  });
+  } = useApi<ProjectMember[]>(
+    () =>
+      workspaceStore.activeWorkspaceId
+        ? `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/members`
+        : `/api/v1/workspaces/0/projects/${projectId}/members`,
+    {
+      key: `project-members-${projectId}`,
+    }
+  );
 
   const addMember = async (email: string) => {
+    if (!workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/projects/${projectId}/members`, {
-        method: "POST",
-        body: { email, role: "MEMBER" },
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/members`,
+        {
+          method: "POST",
+          body: { email, role: "MEMBER" },
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to add member", err);
@@ -87,10 +107,14 @@ export const useProjectMembers = (projectId: string) => {
   };
 
   const removeMember = async (userId: string) => {
+    if (!workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/projects/${projectId}/members/${userId}`, {
-        method: "DELETE",
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/members/${userId}`,
+        {
+          method: "DELETE",
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to remove member", err);
@@ -109,21 +133,33 @@ export const useProjectMembers = (projectId: string) => {
 };
 
 export const useProjectTeams = (projectId: string) => {
+  const workspaceStore = useWorkspaceStore();
+
   const {
     data: teams,
     pending: isLoading,
     error,
     refresh,
-  } = useApi<ProjectTeam[]>(`/api/v1/projects/${projectId}/teams`, {
-    key: `project-teams-${projectId}`,
-  });
+  } = useApi<ProjectTeam[]>(
+    () =>
+      workspaceStore.activeWorkspaceId
+        ? `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/teams`
+        : `/api/v1/workspaces/0/projects/${projectId}/teams`,
+    {
+      key: `project-teams-${projectId}`,
+    }
+  );
 
   const addTeam = async (teamId: string) => {
+    if (!workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/projects/${projectId}/teams`, {
-        method: "POST",
-        body: { team_id: teamId },
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/teams`,
+        {
+          method: "POST",
+          body: { team_id: teamId },
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to add team", err);
@@ -132,10 +168,14 @@ export const useProjectTeams = (projectId: string) => {
   };
 
   const removeTeam = async (teamId: string) => {
+    if (!workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/projects/${projectId}/teams/${teamId}`, {
-        method: "DELETE",
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/teams/${teamId}`,
+        {
+          method: "DELETE",
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to remove team", err);

--- a/nuxt-app/app/composables/useTasks.ts
+++ b/nuxt-app/app/composables/useTasks.ts
@@ -1,16 +1,21 @@
 import type { Task, Comment, TaskPriority, TaskStatus } from "~/types";
 
 export const useTasks = (projectId?: string) => {
+  const workspaceStore = useWorkspaceStore();
+
   const {
     data: tasks,
     pending: isLoading,
     error,
     refresh,
   } = useApi<Task[]>(
-    () => (projectId ? `/api/v1/projects/${projectId}/tasks` : null),
+    () =>
+      projectId && workspaceStore.activeWorkspaceId
+        ? `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks`
+        : null,
     {
       key: `tasks-list-${projectId}`,
-      watch: [() => projectId],
+      watch: [() => projectId, () => workspaceStore.activeWorkspaceId],
     }
   );
 
@@ -22,12 +27,15 @@ export const useTasks = (projectId?: string) => {
     assignee_id?: string;
     due_date?: string;
   }) => {
-    if (!projectId) return;
+    if (!projectId || !workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/projects/${projectId}/tasks`, {
-        method: "POST",
-        body: task,
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks`,
+        {
+          method: "POST",
+          body: task,
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to create task", err);
@@ -36,11 +44,15 @@ export const useTasks = (projectId?: string) => {
   };
 
   const updateTask = async (taskId: string, updates: Partial<Task>) => {
+    if (!projectId || !workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/tasks/${taskId}`, {
-        method: "PATCH",
-        body: updates,
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks/${taskId}`,
+        {
+          method: "PATCH",
+          body: updates,
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to update task", err);
@@ -49,10 +61,14 @@ export const useTasks = (projectId?: string) => {
   };
 
   const deleteTask = async (taskId: string) => {
+    if (!projectId || !workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/tasks/${taskId}`, {
-        method: "DELETE",
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks/${taskId}`,
+        {
+          method: "DELETE",
+        }
+      );
       await refresh();
     } catch (err) {
       console.error("Failed to delete task", err);
@@ -71,31 +87,49 @@ export const useTasks = (projectId?: string) => {
   };
 };
 
-export const useTask = (taskId: string) => {
+export const useTask = (projectId: string, taskId: string) => {
+  const workspaceStore = useWorkspaceStore();
+
   const {
     data: task,
     pending: taskLoading,
     error: taskError,
     refresh: refreshTask,
-  } = useApi<Task>(`/api/v1/tasks/${taskId}`, {
-    key: `task-${taskId}`,
-  });
+  } = useApi<Task>(
+    () =>
+      workspaceStore.activeWorkspaceId
+        ? `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks/${taskId}`
+        : `/api/v1/workspaces/0/projects/${projectId}/tasks/${taskId}`,
+    {
+      key: `task-${taskId}`,
+    }
+  );
 
   const {
     data: comments,
     pending: commentsLoading,
     error: commentsError,
     refresh: refreshComments,
-  } = useApi<Comment[]>(`/api/v1/tasks/${taskId}/comments`, {
-    key: `task-comments-${taskId}`,
-  });
+  } = useApi<Comment[]>(
+    () =>
+      workspaceStore.activeWorkspaceId
+        ? `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks/${taskId}/comments`
+        : `/api/v1/workspaces/0/projects/${projectId}/tasks/${taskId}/comments`,
+    {
+      key: `task-comments-${taskId}`,
+    }
+  );
 
   const createComment = async (content: string) => {
+    if (!workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/tasks/${taskId}/comments`, {
-        method: "POST",
-        body: { content },
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks/${taskId}/comments`,
+        {
+          method: "POST",
+          body: { content },
+        }
+      );
       await refreshComments();
     } catch (err) {
       console.error("Failed to create comment", err);
@@ -104,10 +138,14 @@ export const useTask = (taskId: string) => {
   };
 
   const deleteComment = async (commentId: string) => {
+    if (!workspaceStore.activeWorkspaceId) return;
     try {
-      await useMutation(`/api/v1/comments/${commentId}`, {
-        method: "DELETE",
-      });
+      await useMutation(
+        `/api/v1/workspaces/${workspaceStore.activeWorkspaceId}/projects/${projectId}/tasks/${taskId}/comments/${commentId}`,
+        {
+          method: "DELETE",
+        }
+      );
       await refreshComments();
     } catch (err) {
       console.error("Failed to delete comment", err);

--- a/nuxt-app/app/pages/projects/[projectId]/tasks/[taskId].vue
+++ b/nuxt-app/app/pages/projects/[projectId]/tasks/[taskId].vue
@@ -38,7 +38,7 @@ const {
   refreshComments,
   createComment,
   deleteComment,
-} = useTask(taskId.value);
+} = useTask(projectId.value, taskId.value);
 
 const { updateTask, deleteTask } = useTasks(projectId.value);
 const { members } = useProjectMembers(projectId.value);


### PR DESCRIPTION
## Description
This PR refactors the API interaction layer in the Nuxt frontend to match the Golang backend's nested route structure. This ensures that every request to project or task resources carries the appropriate `workspaceId` context required for access control verification.

## Linked Issue
- Fixes: #123 

## Changes
- **Composables**:
    - `useProjects.ts`: Updated `useProject`, `useProjectMembers`, and `useProjectTeams` to use nested `/workspaces/:wsId/projects/...` paths.
    - `useTasks.ts`: Updated `useTasks` and `useTask` to include both workspace and project IDs in the URL.
    - `useTask` signature changed to `(projectId: string, taskId: string)`.
- **Pages & Components**:
    - `pages/projects/[projectId]/tasks/[taskId].vue`: Updated `useTask` call to pass the project context.
    - `components/tasks/Dialog.vue`: Injected `activeProjectId` into the `useTask` composable.

## Verification
- [x] Verified all "Project not found" errors are resolved.
- [x] Confirmed that the `CheckAccess` middleware on the backend now receives the `workspaceId` correctly.
- [x] Tested full Task CRUD and Commenting functionality.