### PR TITLE
refactor(services): migrate WorkspaceService to atomic transactions

### DIFF
--- a/golang-backend/services/workspace.go
+++ b/golang-backend/services/workspace.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 
@@ -9,78 +10,81 @@ import (
 	"github.com/AshvinBambhaniya/nexus-tasks/models"
 	"github.com/AshvinBambhaniya/nexus-tasks/pkg/structs"
 	"github.com/AshvinBambhaniya/nexus-tasks/pkg/watermill"
-	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
-type WorkspaceService struct {
-	workspaceModel *models.WorkspaceModel
-	userModel      *models.UserModel
-	publisher      *watermill.WatermillPublisher
-	db             *goqu.Database
-	logger         *zap.Logger
+type WorkspaceService interface {
+	CreateWorkspace(ownerID uuid.UUID, req structs.ReqCreateWorkspace) (models.Workspace, error)
+	ListWorkspacesByUserID(userID uuid.UUID) ([]models.Workspace, error)
+	ListMembersByWorkspaceId(workspaceID uuid.UUID) ([]models.WorkspaceMemberWithUser, error)
+	InviteMember(requestorID, workspaceID uuid.UUID, email string) error
+	RemoveMember(requestorID, workspaceID, userID uuid.UUID) error
+	ValidateAccess(userID, workspaceID uuid.UUID) (models.WorkspaceMember, error)
 }
 
-func NewWorkspaceService(db *goqu.Database, logger *zap.Logger, workspaceModel *models.WorkspaceModel, userModel *models.UserModel, publisher *watermill.WatermillPublisher) *WorkspaceService {
-	return &WorkspaceService{
-		workspaceModel: workspaceModel,
-		userModel:      userModel,
-		publisher:      publisher,
-		db:             db,
-		logger:         logger,
+type workspaceService struct {
+	storage   models.Storage
+	publisher watermill.Publisher
+	logger    *zap.Logger
+}
+
+func NewWorkspaceService(storage models.Storage, logger *zap.Logger, publisher watermill.Publisher) WorkspaceService {
+	return &workspaceService{
+		storage:   storage,
+		publisher: publisher,
+		logger:    logger,
 	}
 }
 
 // CreateWorkspace creates a TEAM workspace and adds the creator as ADMIN
-func (s *WorkspaceService) CreateWorkspace(ownerID uuid.UUID, req structs.ReqCreateWorkspace) (models.Workspace, error) {
-	ws := models.Workspace{
-		Name:    req.Name,
-		Type:    models.WorkspaceTypeTeam,
-		OwnerID: ownerID,
-	}
+func (s *workspaceService) CreateWorkspace(ownerID uuid.UUID, req structs.ReqCreateWorkspace) (models.Workspace, error) {
+	var createdWs models.Workspace
 
-	isOk := false
-	transaction, err := s.db.Begin()
+	err := s.storage.Atomic(context.Background(), func(txStorage models.Storage) error {
+		ws := models.Workspace{
+			Name:    req.Name,
+			Type:    models.WorkspaceTypeTeam,
+			OwnerID: ownerID,
+		}
+
+		// 1. Create Workspace
+		var err error
+		createdWs, err = txStorage.Workspaces().CreateWorkspace(ws)
+		if err != nil {
+			return err
+		}
+
+		// 2. Add Owner as Admin
+		err = txStorage.Workspaces().AddMember(models.WorkspaceMember{
+			WorkspaceID: createdWs.ID,
+			UserID:      ownerID,
+			Role:        models.WorkspaceRoleAdmin,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
 	if err != nil {
+		s.logger.Error("failed to create workspace", zap.Error(err))
 		return models.Workspace{}, err
 	}
 
-	defer func() {
-		if isOk {
-			err := transaction.Commit()
-			if err != nil {
-				s.logger.Error("error during commit in create workspace", zap.Error(err))
-			}
-		} else {
-			err := transaction.Rollback()
-			if err != nil {
-				s.logger.Error("error during rollback in create workspace", zap.Error(err))
-			}
-		}
-	}()
-
-	// 1. Create Workspace
-	createdWs, err := s.workspaceModel.CreateWorkspace(transaction, ws)
-	if err != nil {
-		return createdWs, err
-	}
-
-	// 2. Add Owner as Admin
-	err = s.workspaceModel.AddMemberTx(transaction, models.WorkspaceMember{
-		WorkspaceID: createdWs.ID,
-		UserID:      ownerID,
-		Role:        models.WorkspaceRoleAdmin,
-	})
-	if err != nil {
-		return createdWs, err
-	}
-
-	isOk = true
 	return createdWs, nil
 }
 
-func (s *WorkspaceService) InviteMember(requestorID, workspaceID uuid.UUID, email string) error {
+func (s *workspaceService) ListWorkspacesByUserID(userID uuid.UUID) ([]models.Workspace, error) {
+	return s.storage.Workspaces().ListWorkspacesByUserID(userID)
+}
+
+func (s *workspaceService) ListMembersByWorkspaceId(workspaceID uuid.UUID) ([]models.WorkspaceMemberWithUser, error) {
+	return s.storage.Workspaces().ListMembersByWorkspaceId(workspaceID)
+}
+
+func (s *workspaceService) InviteMember(requestorID, workspaceID uuid.UUID, email string) error {
 	// 1. Validate Admin Access (Internal check required here as role check is specific)
 	member, err := s.ValidateAccess(requestorID, workspaceID)
 	if err != nil {
@@ -92,7 +96,7 @@ func (s *WorkspaceService) InviteMember(requestorID, workspaceID uuid.UUID, emai
 	}
 
 	// 2. Find User by Email
-	user, err := s.userModel.GetByEmail(email)
+	user, err := s.storage.Users().GetByEmail(email)
 	if err != nil {
 		s.logger.Error("user not found for email", zap.String("email", email), zap.Error(err))
 		if err == sql.ErrNoRows {
@@ -102,14 +106,14 @@ func (s *WorkspaceService) InviteMember(requestorID, workspaceID uuid.UUID, emai
 	}
 
 	// 3. Check if already member
-	_, err = s.workspaceModel.GetMember(workspaceID, user.ID)
+	_, err = s.storage.Workspaces().GetMember(workspaceID, user.ID)
 	if err == nil {
 		s.logger.Error("user is already a member of the workspace", zap.Any("workspaceID", workspaceID), zap.Any("userID", user.ID))
 		return errors.New("user is already a member")
 	}
 
 	// 4. Add Member
-	err = s.workspaceModel.AddMember(models.WorkspaceMember{
+	err = s.storage.Workspaces().AddMember(models.WorkspaceMember{
 		WorkspaceID: workspaceID,
 		UserID:      user.ID,
 		Role:        models.WorkspaceRoleMember,
@@ -121,7 +125,7 @@ func (s *WorkspaceService) InviteMember(requestorID, workspaceID uuid.UUID, emai
 	}
 
 	// 5. Send Notification (Async)
-	workspace, err := s.workspaceModel.GetByID(workspaceID)
+	workspace, err := s.storage.Workspaces().GetByID(workspaceID)
 	if err == nil && s.publisher != nil {
 		err = s.publisher.Publish(constants.TopicWorkspaceInvites, workers.WorkspaceInvitationMail{
 			Email:         email,
@@ -136,7 +140,7 @@ func (s *WorkspaceService) InviteMember(requestorID, workspaceID uuid.UUID, emai
 	return nil
 }
 
-func (s *WorkspaceService) RemoveMember(requestorID, workspaceID, userID uuid.UUID) error {
+func (s *workspaceService) RemoveMember(requestorID, workspaceID, userID uuid.UUID) error {
 	// 1. Validate Admin Access
 	member, err := s.ValidateAccess(requestorID, workspaceID)
 	if err != nil {
@@ -147,12 +151,12 @@ func (s *WorkspaceService) RemoveMember(requestorID, workspaceID, userID uuid.UU
 	}
 
 	// 2. Remove
-	return s.workspaceModel.RemoveMember(nil, workspaceID, userID)
+	return s.storage.Workspaces().RemoveMember(workspaceID, userID)
 }
 
 // ValidateAccess checks if a user is a member of the workspace (Internal Helper)
-func (s *WorkspaceService) ValidateAccess(userID, workspaceID uuid.UUID) (models.WorkspaceMember, error) {
-	member, err := s.workspaceModel.GetMember(workspaceID, userID)
+func (s *workspaceService) ValidateAccess(userID, workspaceID uuid.UUID) (models.WorkspaceMember, error) {
+	member, err := s.storage.Workspaces().GetMember(workspaceID, userID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return models.WorkspaceMember{}, errors.New("unauthorized: not a member of this workspace")


### PR DESCRIPTION
## Description
Migrates `WorkspaceService` to the interface-driven model and implements the new `Atomic` transaction pattern for multi-repository operations.

## Related Issues
- Closes #133 

## Changes
- `WorkspaceService` converted to interface.
- Implemented `Atomic` block in `CreateWorkspace` to handle both workspace and member creation.
- Updated `InviteMember` to use `watermill.Publisher` interface for notifications.

## Why this is needed
To ensure data consistency during workspace setup and to decouple notification logic from the service implementation.

## Checklist
- [x] `Atomic` transaction verified for rollbacks.
- [x] Role-Based Access Control (RBAC) logic isolated in service.
- [x] Publisher dependency injected correctly.
