### PR TITLE
feat(services): refactor Team and Comment services to use interfaces and centralized access validation

### DIFF
--- a/golang-backend/services/comment.go
+++ b/golang-backend/services/comment.go
@@ -1,37 +1,39 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	"github.com/AshvinBambhaniya/nexus-tasks/models"
 	"github.com/AshvinBambhaniya/nexus-tasks/pkg/structs"
-	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
-type CommentService struct {
-	commentModel   *models.CommentModel
-	taskModel      *models.TaskModel
-	projectService *ProjectService
-	db             *goqu.Database
+type CommentService interface {
+	CreateComment(userID, taskID uuid.UUID, req structs.ReqCreateComment) (models.Comment, error)
+	ListTaskComments(userID, taskID uuid.UUID) ([]models.CommentWithAuthor, error)
+	DeleteComment(userID, commentID uuid.UUID) error
+}
+
+type commentService struct {
+	storage        models.Storage
+	projectService ProjectService
 	logger         *zap.Logger
 }
 
-func NewCommentService(db *goqu.Database, logger *zap.Logger, commentModel *models.CommentModel, taskModel *models.TaskModel, projectService *ProjectService) *CommentService {
-	return &CommentService{
-		commentModel:   commentModel,
-		taskModel:      taskModel,
+func NewCommentService(storage models.Storage, projectService ProjectService, logger *zap.Logger) CommentService {
+	return &commentService{
+		storage:        storage,
 		projectService: projectService,
-		db:             db,
 		logger:         logger,
 	}
 }
 
-func (s *CommentService) CreateComment(userID, taskID uuid.UUID, req structs.ReqCreateComment) (models.Comment, error) {
+func (s *commentService) CreateComment(userID, taskID uuid.UUID, req structs.ReqCreateComment) (models.Comment, error) {
 	// 1. Verify Task Access
-	task, err := s.taskModel.GetByID(taskID)
+	task, err := s.storage.Tasks().GetByID(taskID)
 	if err != nil {
 		return models.Comment{}, errors.New("task not found")
 	}
@@ -42,44 +44,30 @@ func (s *CommentService) CreateComment(userID, taskID uuid.UUID, req structs.Req
 		return models.Comment{}, err
 	}
 
-	comment := models.Comment{
-		Content:   req.Content,
-		TaskID:    taskID,
-		AuthorID:  userID,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
-	}
-
-	isOk := false
-	transaction, err := s.db.Begin()
-	if err != nil {
-		return models.Comment{}, err
-	}
-	defer func() {
-		if isOk {
-			err := transaction.Commit()
-			if err != nil {
-				s.logger.Error("error during commit in create comment", zap.Error(err))
-			}
-		} else {
-			err := transaction.Rollback()
-			if err != nil {
-				s.logger.Error("error during rollback in create comment", zap.Error(err))
-			}
+	var createdComment models.Comment
+	err = s.storage.Atomic(context.Background(), func(txStorage models.Storage) error {
+		comment := models.Comment{
+			Content:   req.Content,
+			TaskID:    taskID,
+			AuthorID:  userID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
 		}
-	}()
 
-	createdComment, err := s.commentModel.Create(transaction, comment)
+		var err error
+		createdComment, err = txStorage.Comments().Create(comment)
+		return err
+	})
+
 	if err != nil {
 		return models.Comment{}, err
 	}
 
-	isOk = true
 	return createdComment, nil
 }
 
-func (s *CommentService) ListTaskComments(userID, taskID uuid.UUID) ([]models.CommentWithAuthor, error) {
-	task, err := s.taskModel.GetByID(taskID)
+func (s *commentService) ListTaskComments(userID, taskID uuid.UUID) ([]models.CommentWithAuthor, error) {
+	task, err := s.storage.Tasks().GetByID(taskID)
 	if err != nil {
 		return nil, errors.New("task not found")
 	}
@@ -89,11 +77,11 @@ func (s *CommentService) ListTaskComments(userID, taskID uuid.UUID) ([]models.Co
 		return nil, err
 	}
 
-	return s.commentModel.ListByTaskID(taskID)
+	return s.storage.Comments().ListByTaskID(taskID)
 }
 
-func (s *CommentService) DeleteComment(userID, commentID uuid.UUID) error {
-	comment, err := s.commentModel.GetByID(commentID)
+func (s *commentService) DeleteComment(userID, commentID uuid.UUID) error {
+	comment, err := s.storage.Comments().GetByID(commentID)
 	if err != nil {
 		return errors.New("comment not found")
 	}
@@ -103,30 +91,7 @@ func (s *CommentService) DeleteComment(userID, commentID uuid.UUID) error {
 		return errors.New("unauthorized: only author can delete comment")
 	}
 
-	isOk := false
-	transaction, err := s.db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if isOk {
-			err := transaction.Commit()
-			if err != nil {
-				s.logger.Error("error during commit in delete comment", zap.Error(err))
-			}
-		} else {
-			err := transaction.Rollback()
-			if err != nil {
-				s.logger.Error("error during rollback in delete comment", zap.Error(err))
-			}
-		}
-	}()
-
-	err = s.commentModel.Delete(transaction, commentID)
-	if err != nil {
-		return err
-	}
-
-	isOk = true
-	return nil
+	return s.storage.Atomic(context.Background(), func(txStorage models.Storage) error {
+		return txStorage.Comments().Delete(commentID)
+	})
 }

--- a/golang-backend/services/health.go
+++ b/golang-backend/services/health.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"github.com/AshvinBambhaniya/nexus-tasks/models"
+	"go.uber.org/zap"
+)
+
+type HealthService interface {
+	CheckDatabaseHealth(ctx context.Context) error
+}
+
+type healthService struct {
+	storage models.Storage
+	logger  *zap.Logger
+}
+
+func NewHealthService(storage models.Storage, logger *zap.Logger) HealthService {
+	return &healthService{
+		storage: storage,
+		logger:  logger,
+	}
+}
+
+func (s *healthService) CheckDatabaseHealth(ctx context.Context) error {
+	return s.storage.CheckHealth(ctx)
+}

--- a/golang-backend/services/team.go
+++ b/golang-backend/services/team.go
@@ -1,39 +1,42 @@
 package services
 
 import (
+	"context"
 	"errors"
 
 	"github.com/AshvinBambhaniya/nexus-tasks/models"
 	"github.com/AshvinBambhaniya/nexus-tasks/pkg/structs"
-	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
-type TeamService struct {
-	teamModel      *models.TeamModel
-	projectModel   *models.ProjectModel
-	workspaceModel *models.WorkspaceModel
-	userModel      *models.UserModel
-	db             *goqu.Database
-	logger         *zap.Logger
+type TeamService interface {
+	CreateTeam(userID uuid.UUID, workspaceID uuid.UUID, req structs.ReqCreateTeam) (models.Team, error)
+	GetTeam(teamID uuid.UUID) (structs.ResTeamWithProjects, error)
+	ListTeamsByWorkspaceID(workspaceID uuid.UUID) ([]models.Team, error)
+	UpdateTeam(requestorID, workspaceID, teamID uuid.UUID, req structs.ReqUpdateTeam) (models.Team, error)
+	DeleteTeam(requestorID, workspaceID, teamID uuid.UUID) error
+	AddMember(requestorID, workspaceID, teamID uuid.UUID, email, role string) error
+	RemoveMember(requestorID, workspaceID, teamID, userID uuid.UUID) error
+	ListMembersByTeamId(teamID uuid.UUID) ([]models.TeamMemberWithUser, error)
 }
 
-func NewTeamService(db *goqu.Database, logger *zap.Logger, teamModel *models.TeamModel, projectModel *models.ProjectModel, workspaceModel *models.WorkspaceModel, userModel *models.UserModel) *TeamService {
-	return &TeamService{
-		teamModel:      teamModel,
-		projectModel:   projectModel,
-		workspaceModel: workspaceModel,
-		userModel:      userModel,
-		db:             db,
-		logger:         logger,
+type teamService struct {
+	storage models.Storage
+	logger  *zap.Logger
+}
+
+func NewTeamService(storage models.Storage, logger *zap.Logger) TeamService {
+	return &teamService{
+		storage: storage,
+		logger:  logger,
 	}
 }
 
 // CreateTeam creates a new team in a workspace and adds the creator as admin
-func (s *TeamService) CreateTeam(userID uuid.UUID, workspaceID uuid.UUID, req structs.ReqCreateTeam) (models.Team, error) {
+func (s *teamService) CreateTeam(userID uuid.UUID, workspaceID uuid.UUID, req structs.ReqCreateTeam) (models.Team, error) {
 	// 1. Verify User is Workspace Admin (Requirement from Python logic)
-	member, err := s.workspaceModel.GetMember(workspaceID, userID)
+	member, err := s.storage.Workspaces().GetMember(workspaceID, userID)
 	if err != nil {
 		return models.Team{}, err
 	}
@@ -41,62 +44,50 @@ func (s *TeamService) CreateTeam(userID uuid.UUID, workspaceID uuid.UUID, req st
 		return models.Team{}, errors.New("unauthorized: only workspace admins can create teams")
 	}
 
-	team := models.Team{
-		Name:        req.Name,
-		Description: req.Description,
-		WorkspaceID: workspaceID,
-	}
+	var createdTeam models.Team
+	err = s.storage.Atomic(context.Background(), func(txStorage models.Storage) error {
+		team := models.Team{
+			Name:        req.Name,
+			Description: req.Description,
+			WorkspaceID: workspaceID,
+		}
 
-	isOk := false
-	transaction, err := s.db.Begin()
+		var err error
+		createdTeam, err = txStorage.Teams().CreateTeam(team)
+		if err != nil {
+			s.logger.Error("failed to create team", zap.Error(err))
+			return err
+		}
+
+		// Add creator as Team Admin
+		err = txStorage.Teams().AddMember(models.TeamMember{
+			TeamID: createdTeam.ID,
+			UserID: userID,
+			Role:   models.TeamRoleAdmin,
+		})
+		if err != nil {
+			s.logger.Error("failed to add team member", zap.Error(err))
+			return err
+		}
+		return nil
+	})
+
 	if err != nil {
 		return models.Team{}, err
 	}
 
-	defer func() {
-		if isOk {
-			err := transaction.Commit()
-			if err != nil {
-				s.logger.Error("error during commit in create team", zap.Error(err))
-			}
-		} else {
-			err := transaction.Rollback()
-			if err != nil {
-				s.logger.Error("error during rollback in create team", zap.Error(err))
-			}
-		}
-	}()
-
-	createdTeam, err := s.teamModel.CreateTeam(transaction, team)
-	if err != nil {
-		s.logger.Error("failed to create team", zap.Error(err))
-		return createdTeam, err
-	}
-
-	// Add creator as Team Admin
-	err = s.teamModel.AddMember(transaction, models.TeamMember{
-		TeamID: createdTeam.ID,
-		UserID: userID,
-		Role:   models.TeamRoleAdmin,
-	})
-	if err != nil {
-		s.logger.Error("failed to add team member", zap.Error(err))
-		return createdTeam, err
-	}
-
-	isOk = true
 	return createdTeam, nil
 }
 
-func (s *TeamService) GetTeam(teamID uuid.UUID) (structs.ResTeamWithProjects, error) {
+func (s *teamService) GetTeam(teamID uuid.UUID) (structs.ResTeamWithProjects, error) {
 
-	team, err := s.teamModel.GetByID(teamID)
+	team, err := s.storage.Teams().GetByID(teamID)
 	if err != nil {
 		s.logger.Error("error while get team by teamID", zap.Error(err))
 		return structs.ResTeamWithProjects{}, err
 	}
 
-	projects, err := s.projectModel.ListByTeamID(teamID)
+	projects, err := s.storage.Projects().ListByTeamID(teamID)
 	if err != nil {
 		s.logger.Error("error while list project by teamID", zap.Error(err))
 		return structs.ResTeamWithProjects{}, err
@@ -113,25 +104,29 @@ func (s *TeamService) GetTeam(teamID uuid.UUID) (structs.ResTeamWithProjects, er
 	}, err
 }
 
-func (s *TeamService) UpdateTeam(requestorID, workspaceID, teamID uuid.UUID, req structs.ReqUpdateTeam) (models.Team, error) {
+func (s *teamService) ListTeamsByWorkspaceID(workspaceID uuid.UUID) ([]models.Team, error) {
+	return s.storage.Teams().ListTeamsByWorkspaceID(workspaceID)
+}
+
+func (s *teamService) UpdateTeam(requestorID, workspaceID, teamID uuid.UUID, req structs.ReqUpdateTeam) (models.Team, error) {
 	// Verify Access (Team Admin or Workspace Admin)
 	// For simplicity, let's allow Workspace Admin or Team Admin.
 	// Check Team Admin
 	isTeamAdmin := false
-	teamMember, err := s.teamModel.GetMember(teamID, requestorID)
+	teamMember, err := s.storage.Teams().GetMember(teamID, requestorID)
 	if err == nil && teamMember.Role == models.TeamRoleAdmin {
 		isTeamAdmin = true
 	}
 
 	if !isTeamAdmin {
 		// Check Workspace Admin
-		wsMember, err := s.workspaceModel.GetMember(workspaceID, requestorID)
+		wsMember, err := s.storage.Workspaces().GetMember(workspaceID, requestorID)
 		if err != nil || wsMember.Role != models.WorkspaceRoleAdmin {
 			return models.Team{}, errors.New("unauthorized: team admin or workspace admin required")
 		}
 	}
 
-	team, err := s.teamModel.GetByID(teamID)
+	team, err := s.storage.Teams().GetByID(teamID)
 	if err != nil {
 		return models.Team{}, err
 	}
@@ -143,7 +138,7 @@ func (s *TeamService) UpdateTeam(requestorID, workspaceID, teamID uuid.UUID, req
 		team.Description = req.Description
 	}
 
-	updatedTeam, err := s.teamModel.UpdateTeam(team)
+	updatedTeam, err := s.storage.Teams().UpdateTeam(team)
 	if err != nil {
 		s.logger.Error("error while update the team", zap.Error(err))
 		return models.Team{}, err
@@ -152,18 +147,18 @@ func (s *TeamService) UpdateTeam(requestorID, workspaceID, teamID uuid.UUID, req
 	return updatedTeam, nil
 }
 
-func (s *TeamService) DeleteTeam(requestorID, workspaceID, teamID uuid.UUID) error {
+func (s *teamService) DeleteTeam(requestorID, workspaceID, teamID uuid.UUID) error {
 	isAuthorized := false
 
 	// 1. Check Team Admin
-	teamMember, err := s.teamModel.GetMember(teamID, requestorID)
+	teamMember, err := s.storage.Teams().GetMember(teamID, requestorID)
 	if err == nil && teamMember.Role == models.TeamRoleAdmin {
 		isAuthorized = true
 	}
 
 	// 2. Check Workspace Admin (Override)
 	if !isAuthorized {
-		wsMember, err := s.workspaceModel.GetMember(workspaceID, requestorID)
+		wsMember, err := s.storage.Workspaces().GetMember(workspaceID, requestorID)
 		if err == nil && wsMember.Role == models.WorkspaceRoleAdmin {
 			isAuthorized = true
 		}
@@ -173,7 +168,7 @@ func (s *TeamService) DeleteTeam(requestorID, workspaceID, teamID uuid.UUID) err
 		return errors.New("unauthorized")
 	}
 
-	err = s.teamModel.DeleteTeam(teamID)
+	err = s.storage.Teams().DeleteTeam(teamID)
 	if err != nil {
 		s.logger.Error("error while deleting the team", zap.Error(err))
 		return err
@@ -182,15 +177,15 @@ func (s *TeamService) DeleteTeam(requestorID, workspaceID, teamID uuid.UUID) err
 	return nil
 }
 
-func (s *TeamService) AddMember(requestorID, workspaceID, teamID uuid.UUID, email, role string) error {
+func (s *teamService) AddMember(requestorID, workspaceID, teamID uuid.UUID, email, role string) error {
 	// Verify Admin
 	isAuthorized := false
-	teamMember, err := s.teamModel.GetMember(teamID, requestorID)
+	teamMember, err := s.storage.Teams().GetMember(teamID, requestorID)
 	if err == nil && teamMember.Role == models.TeamRoleAdmin {
 		isAuthorized = true
 	}
 	if !isAuthorized {
-		wsMember, err := s.workspaceModel.GetMember(workspaceID, requestorID)
+		wsMember, err := s.storage.Workspaces().GetMember(workspaceID, requestorID)
 		if err == nil && wsMember.Role == models.WorkspaceRoleAdmin {
 			isAuthorized = true
 		}
@@ -200,13 +195,13 @@ func (s *TeamService) AddMember(requestorID, workspaceID, teamID uuid.UUID, emai
 	}
 
 	// Find User
-	user, err := s.userModel.GetByEmail(email)
+	user, err := s.storage.Users().GetByEmail(email)
 	if err != nil {
 		return errors.New("user not found")
 	}
 
 	// Check if already in team
-	_, err = s.teamModel.GetMember(teamID, user.ID)
+	_, err = s.storage.Teams().GetMember(teamID, user.ID)
 	if err == nil {
 		return errors.New("user already in team")
 	}
@@ -216,41 +211,24 @@ func (s *TeamService) AddMember(requestorID, workspaceID, teamID uuid.UUID, emai
 		return errors.New("invalid role")
 	}
 
-	isOk := false
-	transaction, err := s.db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if isOk {
-			transaction.Commit()
-		} else {
-			transaction.Rollback()
-		}
-	}()
-
-	err = s.teamModel.AddMember(transaction, models.TeamMember{
-		TeamID: teamID,
-		UserID: user.ID,
-		Role:   models.TeamRole(role),
+	return s.storage.Atomic(context.Background(), func(txStorage models.Storage) error {
+		return txStorage.Teams().AddMember(models.TeamMember{
+			TeamID: teamID,
+			UserID: user.ID,
+			Role:   models.TeamRole(role),
+		})
 	})
-	if err != nil {
-		return err
-	}
-
-	isOk = true
-	return nil
 }
 
-func (s *TeamService) RemoveMember(requestorID, workspaceID, teamID, userID uuid.UUID) error {
+func (s *teamService) RemoveMember(requestorID, workspaceID, teamID, userID uuid.UUID) error {
 	// Verify Admin
 	isAuthorized := false
-	teamMember, err := s.teamModel.GetMember(teamID, requestorID)
+	teamMember, err := s.storage.Teams().GetMember(teamID, requestorID)
 	if err == nil && teamMember.Role == models.TeamRoleAdmin {
 		isAuthorized = true
 	}
 	if !isAuthorized {
-		wsMember, err := s.workspaceModel.GetMember(workspaceID, requestorID)
+		wsMember, err := s.storage.Workspaces().GetMember(workspaceID, requestorID)
 		if err == nil && wsMember.Role == models.WorkspaceRoleAdmin {
 			isAuthorized = true
 		}
@@ -259,10 +237,14 @@ func (s *TeamService) RemoveMember(requestorID, workspaceID, teamID, userID uuid
 		return errors.New("unauthorized")
 	}
 
-	err = s.teamModel.RemoveMember(teamID, userID)
+	err = s.storage.Teams().RemoveMember(teamID, userID)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (s *teamService) ListMembersByTeamId(teamID uuid.UUID) ([]models.TeamMemberWithUser, error) {
+	return s.storage.Teams().ListMembersByTeamId(teamID)
 }

--- a/golang-backend/services/websocket.go
+++ b/golang-backend/services/websocket.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type WebsocketService interface {
+	GetConnectionTopics(userID, workspaceID uuid.UUID) ([]string, error)
+}
+
+type websocketService struct {
+	workspaceService WorkspaceService
+	projectService   ProjectService
+	teamService      TeamService
+	logger           *zap.Logger
+}
+
+func NewWebsocketService(
+	workspaceService WorkspaceService,
+	projectService ProjectService,
+	logger *zap.Logger,
+) WebsocketService {
+	return &websocketService{
+		workspaceService: workspaceService,
+		projectService:   projectService,
+		logger:           logger,
+	}
+}
+
+func (s *websocketService) GetConnectionTopics(userID, workspaceID uuid.UUID) ([]string, error) {
+	// 1. Verify Workspace Access
+	_, err := s.workspaceService.ValidateAccess(userID, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	var topics []string
+	// 2. Add Workspace Topic
+	topics = append(topics, fmt.Sprintf("workspace:%s", workspaceID.String()))
+
+	// 3. Get all projects in workspace and check access
+	projects, err := s.projectService.ListByWorkspaceID(workspaceID)
+	if err == nil {
+		for _, p := range projects {
+			if s.checkProjectAccess(p.ID, userID, workspaceID) == nil {
+				topics = append(topics, fmt.Sprintf("project:%s", p.ID.String()))
+			}
+		}
+	}
+
+	return topics, nil
+}
+
+func (s *websocketService) checkProjectAccess(projectID, userID, workspaceID uuid.UUID) error {
+	// Reuse logic from projectService if possible, or keep it here if it's specific to websocket sub logic
+	// Actually, ProjectService has ValidateProjectAccess
+	return s.projectService.ValidateProjectAccess(projectID, userID, false)
+}


### PR DESCRIPTION
## Description
Refactors `TeamService` and `TeamService` to use interfaces and repositories. Centralizes access validation for projects and tasks.

## Related Issues
- Closes #135 

## Changes
- Created interfaces for both `TeamService` and `TeamService`.
- Implemented `ValidateProjectAccess` as a reusable method.

## Why this is needed
To simplify complex comment workflows and ensure that access checks are consistently applied across all team-related operations.

## Checklist
- [x] Cross-service dependency between team and task handled via interfaces.
- [x] Comment repository calls verified.
- [x] Access validation tested for different member roles.
